### PR TITLE
Do not accept a shard that has been seen and warn user

### DIFF
--- a/src/views/Combine.vue
+++ b/src/views/Combine.vue
@@ -59,11 +59,12 @@ export default {
     return {
       title: "",
       nonce: "",
-      shards: new Set(),
+      shards: [],
       qrCodes: [],
       requiredShards: undefined,
       passphrase: "",
-      recoveredSecret: undefined
+      recoveredSecret: undefined,
+      PLACEHOLDER_QR_DATA
     };
   },
   computed: {
@@ -83,8 +84,9 @@ export default {
   },
   methods: {
     onDecode: function(result) {
-      var parsed = crypto.parse(result);
-      if (!this.shards.has(parsed.data)) {
+      const parsed = crypto.parse(result);
+      const jsonParsed = JSON.stringify(parsed);
+      if (!this.shards.includes(jsonParsed)) {
         if (this.title && this.title != parsed.title) {
           console.error("title mismatch!");
           return;
@@ -107,9 +109,10 @@ export default {
           this.requiredShards = parsed.requiredShards;
         }
         this.qrCodes.push(result);
-        this.shards.add(parsed);
+        this.shards.push(jsonParsed);
       } else {
         console.warn("Shard already seen");
+        window.alert("Shard already seen");
       }
     },
     reconstruct: function() {
@@ -120,8 +123,10 @@ export default {
         .split(" ")
         .filter(el => el)
         .join("-");
-      var shards = Array.from(this.shards);
-      this.recoveredSecret = crypto.reconstruct(shards, this.passphrase);
+      this.recoveredSecret = crypto.reconstruct(
+        this.shards.map(JSON.parse),
+        this.passphrase
+      );
     }
   }
 };


### PR DESCRIPTION
Close #15 

### summary
This PR provides a check to ensure that a previously seen shard will not enter the set of recognized shards and provides the user both a console.warn and window.alert to notify them that the shard has been previously seen.

### user experience
It is worth noting, the qr-stream caches the last recognized qr-code and only will emit a new decode event when a different qr code is seen. So this PR does not affect user interaction in the case when the user is continuously trying to scan the same code. Instead a user must do a behavior with the following pattern to encounter the new error message: scan code X, then code Y, and then code X again.

### implementation
The previous implementation attempted to do this same behavior using tests of Set membership for the parsed qr code. However, object equality in javascript is based off of reference and not value, so the membership test was always negative. Here I change the set into an array (we don't except large sets of shards so this ok, and it removes an array conversion), and store the shards as strings, using `JSON.stringify`+`JSON.parse` to ensure the string representations are recursively correct. (Javascript compares strings by value.)