### PR TITLE
fix #76 add default passphrase canvas width

### DIFF
--- a/src/components/CanvasText.vue
+++ b/src/components/CanvasText.vue
@@ -9,8 +9,8 @@ export default Vue.extend({
   name: "CanvasText",
   directives: {
     canvasMessage: function(el: HTMLElement, binding: VNodeDirective): void {
-      const canvasElement = el as HTMLCanvasElement,
-        context = canvasElement.getContext("2d");
+      const canvasElement = el as HTMLCanvasElement;
+      const context = canvasElement.getContext("2d");
       if (!context) {
         // eslint-disable-next-line no-console
         console.warn("Failed to find canvasElement context");
@@ -20,9 +20,10 @@ export default Vue.extend({
       context.fillStyle = "black";
       context.font = "20px Arial";
       const textWidth = context.measureText(binding.value).width || 450;
-      canvasElement.setAttribute("width", textWidth + 20 + "px");
+      const padLeftPx = 15;
+      canvasElement.setAttribute("width", textWidth + padLeftPx + "px");
       context.font = "20px Arial";
-      context.fillText(binding.value, 15, 20);
+      context.fillText(binding.value, padLeftPx, 20);
     }
   },
   props: {

--- a/src/components/CanvasText.vue
+++ b/src/components/CanvasText.vue
@@ -19,8 +19,8 @@ export default Vue.extend({
       context.clearRect(0, 0, canvasElement.width, canvasElement.height);
       context.fillStyle = "black";
       context.font = "20px Arial";
-      const textSize = context.measureText(binding.value);
-      canvasElement.setAttribute("width", textSize.width + 20 + "px");
+      const textWidth = context.measureText(binding.value).width || 450;
+      canvasElement.setAttribute("width", textWidth + 20 + "px");
       context.font = "20px Arial";
       context.fillText(binding.value, 15, 20);
     }


### PR DESCRIPTION
Add default passphrase canvas width, because some browsers block  `measureText` api and return `0` for privacy reasons.

Passphrase consists of 4 words, 9 characters each at most. So `450px` seems sufficient as a default value
![image](https://user-images.githubusercontent.com/7165377/142139666-46a0e179-38ce-43c9-a032-dcad7ebc9059.png)

Here is the result html for testing:
[index.zip](https://github.com/paritytech/banana_split/files/7551991/index.zip)


